### PR TITLE
fix: モバイルでもAPIを叩けるように修正

### DIFF
--- a/src/modules/Ranking.js
+++ b/src/modules/Ranking.js
@@ -13,14 +13,21 @@ const Ranking = () => {
       type: 'text/plain',
     });
     if (result.type === 'success') {
-      setFile(result.file);
+      // Blobに変換するコード （なぜか変換しなくてもうまくいった）
+      // const fetchResponse = await fetch(result.uri);
+      // const blob = await fetchResponse.blob();
+      setFile(result);
     }
   };
 
   // リクエストの作成
   const submitFile = async () => {
     const formData = new FormData();
-    formData.append('file', file);
+    formData.append('file', {
+      uri: file.uri,
+      type: file.mimeType,
+      name: file.name,
+    });
 
     // リクエストの送信＆レスポンスの受け取り
     try {
@@ -56,4 +63,4 @@ const Ranking = () => {
   );
 }
 
-export default Ranking
+export default Ranking;


### PR DESCRIPTION
# やったこと
- モバイルでもAPIを叩けるようにAPIリクエストの作成コードを修正
  - モバイルとブラウザでは、アップロードされたファイルを受け取ったときの形式が異なるらしい
  - つまり、APIリクエストの作成コードをモバイルに対応したものに修正する必要があった

# やらなきゃいけなかったはずなこと
- モバイルでは、アップロードされたファイルをBlob形式に変換してからリクエストを作成する必要があるらしい
  - にもかかわらず、Blob形式に変換しなくてもAPIを叩くことができた
  - [Blob形式に変換するコード](https://snack.expo.dev/@bacon/documentpicker-to-blob)はようやく見つけたので、念のためコメントアウトで残しておきました

# その他
- 今後、いきなりランキングAPIが叩けなくなったら山本のせいなので教えてください