### PR TITLE
画像保存・共有 画像生成後適応ver

### DIFF
--- a/src/modules/GetImage.js
+++ b/src/modules/GetImage.js
@@ -10,6 +10,7 @@ import { NomalLoading } from './Loading';
 import { Loading } from './Loading';
 import KeywordsCloud from './KeywordsCloud';
 import getRandomColorCode from './getRandomColorCode';
+import { ShareImage } from './ShareImage';
 
 import * as DocumentPicker from 'expo-document-picker';
 
@@ -330,9 +331,7 @@ const GetImage = () => {
                                                     {imageUrls.length >= 4 ? <Image style={{ width: '31%', height: 0, paddingBottom: '31%', margin: 4 }} source={{ uri: imageUrls[imageUrls.length - 4] }} resizeMode="contain" /> : ""}
                                                 </View>
                                             )}
-                                        <View style={styles.centerContainer}>
-                                            <Image style={{ width: '100%', height: 0, paddingBottom: '100%', margin: 8 }} source={{ uri: imageUrls[imageUrls.length - 1] }} />
-                                        </View>
+                                        <ShareImage imageUrl={ imageUrls[imageUrls.length - 1] }></ShareImage>
                                     </View>
 
                                     <Text style={styles.finNowPromptTitle}>画像生成に使用した文章</Text>


### PR DESCRIPTION
画像生成後のページに保存機能・共有機能を付与。
前回のシミュ動画と同一。

https://github.com/YuugouOhno/talkImage/assets/106860515/c49ed84c-dfc3-4ba3-89f0-8612f6909b11

